### PR TITLE
Fixed tests and added a couple of suggestions

### DIFF
--- a/classes/shoot.rb
+++ b/classes/shoot.rb
@@ -7,18 +7,21 @@
 
 class Shoot
   def self.get_type(frame)
-      type = :strike if self.is_strike?(frame)
-      type = :spare if self.is_spare?(frame)
-      type = :normal if self.is_normal?(frame)
+    return type = :strike if self.is_strike?(frame)
+    return type = :spare if self.is_spare?(frame)
+    return type = :normal if self.is_normal?(frame)
   end
+
   def self.is_strike?(frame)
-      return true if frame[:first_shoot] == 10
+    return true if frame[:first_shoot] == 10
   end
+
   def self.is_spare? (frame)
-      return true if (frame[:first_shoot] + frame[:second_shoot] == 10) and (frame[:first_shoot] < 10)
+    return true if (frame[:first_shoot] + frame[:second_shoot] == 10) and (frame[:first_shoot] < 10)
   end
-  def self.is_normal?
-      return true if frame[:first_shoot] + frame[:second_shoot] < 10
+
+  def self.is_normal?(frame)
+    return true if frame[:first_shoot] + frame[:second_shoot] < 10
   end
 end
 

--- a/test/shoot_rspec.rb
+++ b/test/shoot_rspec.rb
@@ -2,20 +2,20 @@ require 'rspec'
 require '../classes/shoot.rb'
 
 describe Shoot do
-    describe ".get_type" do
-        it 'Returns strike type ' do
-          strike = {:first_shoot => 10, :two => 0}
-          expect(Shoot.get_type(strike)).to eq :strike
-        end
-
-        it 'Es un spare' do
-          spare = {:first_shoot => 8, :second_shoot => 2}
-          expect(Shoot.get_type(spare)).to eq :spare
-         end
-
-         it 'Es un abierto' do
-          normal = {:first_shoot => 3, :second_shoot => 3}
-          expect(Shoot.get_type(normal)).to eq :strike
-         end
+  describe ".get_type" do
+    it 'Returns strike type ' do
+      strike = {:first_shoot => 10, :second_shoot => 0}
+      expect(Shoot.get_type(strike)).to eq :strike
     end
+
+    it 'Es un spare' do
+      spare = {:first_shoot => 8, :second_shoot => 2}
+      expect(Shoot.get_type(spare)).to eq :spare
+    end
+
+    it 'Es un abierto' do
+      normal = {:first_shoot => 3, :second_shoot => 3}
+      expect(Shoot.get_type(normal)).to eq :normal
+    end
+  end
 end


### PR DESCRIPTION
It was reported in Slack that shot_rspec tests weren't passing despite
that they were pretty simple.

I've made a couple of changes in order to make the tests to pass and
also made some code-style changes in order to make it a bit more clean.

Suggestions:
- Check your indentation, it makes easier to read code when you follow
  conventions. :D
- Ruby always return the last operation that was executed, so, even when
  the `get_type` method sets the right value to `type`, it's needed to
  return it explicitly at the end of the method
- Consider those scenarios in which the sum of both shoots returns 10,
  even when the first one is 10 and the second one 0, since it's running
  sequentially, there is nothing that avoids classifying it as a spare.

  Consider making an early return when any of the conditions is matched.
- It was missed the arg for `is_normal?``

Also, I'd recommend using namend-args rather than passing a single
argument with a hash. While it's simple, you can avoid passing the wrong
hash-struct. Just a thing to keep in mind

https://thoughtbot.com/blog/ruby-2-keyword-arguments